### PR TITLE
Add support for different border styles

### DIFF
--- a/border-characters.js
+++ b/border-characters.js
@@ -1,0 +1,41 @@
+exports.single = {
+	topLeft: '┌',
+	topRight: '┐',
+	bottomRight: '┘',
+	bottomLeft: '└',
+	vertical: '│',
+	horizontal: '─'
+};
+exports.double = {
+	topLeft: '╔',
+	topRight: '╗',
+	bottomRight: '╝',
+	bottomLeft: '╚',
+	vertical: '║',
+	horizontal: '═'
+};
+exports.round = {
+	topLeft: '╭',
+	topRight: '╮',
+	bottomRight: '╯',
+	bottomLeft: '╰',
+	vertical: '│',
+	horizontal: '─'
+};
+// 1st: top and bottom, 2nd: left and right (as in CSS shorthands)
+exports['single-double'] = {
+	topLeft: '╓',
+	topRight: '╖',
+	bottomRight: '╜',
+	bottomLeft: '╙',
+	vertical: '║',
+	horizontal: '─'
+};
+exports['double-single'] = {
+	topLeft: '╒',
+	topRight: '╕',
+	bottomRight: '╛',
+	bottomLeft: '╘',
+	vertical: '│',
+	horizontal: '═'
+};

--- a/example.js
+++ b/example.js
@@ -7,3 +7,24 @@ console.log('\n\n' + boxen(chalk.blue.bold('unicorn'), {
 	margin: 1,
 	borderColor: 'yellow'
 }) + '\n');
+
+console.log('\n\n' + boxen(chalk.blue.bold('unicorn'), {
+	padding: 1,
+	margin: 1,
+	borderColor: 'yellow',
+	borderStyle: 'double'
+}) + '\n');
+
+console.log('\n\n' + boxen(chalk.blue.bold('unicorn'), {
+	padding: 1,
+	margin: 1,
+	borderColor: 'yellow',
+	borderStyle: {
+		topLeft: '+',
+		topRight: '+',
+		bottomLeft: '+',
+		bottomRight: '+',
+		horizontal: '-',
+		vertical: '|'
+	}
+}) + '\n');

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var chalk = require('chalk');
 var objectAssign = require('object-assign');
 var widestLine = require('widest-line');
 var filledArray = require('filled-array');
+var borderChars = require('./border-characters');
 
 var getObject = function (detail) {
 	var obj;
@@ -25,16 +26,35 @@ var getObject = function (detail) {
 	}
 	return obj;
 };
+var getBorderChars = function (borderStyle) {
+	var chars;
+	if(typeof borderStyle === 'string') {
+		chars = borderChars[borderStyle];
+		if (!chars) {
+			throw new TypeError('Invalid borderStyle ' + borderStyle);
+		}
+	} else {
+		['topLeft', 'topRight', 'bottomRight', 'bottomLeft', 'vertical', 'horizontal'].forEach(function (key) {
+			if(!borderStyle[key] || typeof borderStyle[key] !== 'string') {
+				throw new TypeError('Invalid borderStyle, missing or wrong valued key ' + key);
+			}
+		});
+		chars = borderStyle;
+	}
+	return chars;
+}
 
 module.exports = function (text, opts) {
 	opts = objectAssign({
-		padding: 0
+		padding: 0,
+		borderStyle: 'single'
 	}, opts);
 
 	if (opts.borderColor && !chalk[opts.borderColor]) {
 		throw new Error(opts.borderColor + ' is not a valid borderColor');
 	}
 
+	var chars = getBorderChars(opts.borderStyle);
 	var padding = getObject(opts.padding);
 	var margin = getObject(opts.margin);
 
@@ -53,10 +73,10 @@ module.exports = function (text, opts) {
 	}
 
 	var contentWidth = widestLine(text) + padding.left + padding.right;
-	var horizontal = repeating('─', contentWidth);
-	var top = colorizeBorder(repeating('\n', margin.top) + repeating(' ', margin.left) + '┌' + horizontal + '┐');
-	var bottom = colorizeBorder(repeating(' ', margin.left) + '└' + horizontal + '┘' + repeating('\n', margin.bottom));
-	var side = colorizeBorder('│');
+	var horizontal = repeating(chars.horizontal, contentWidth);
+	var top = colorizeBorder(repeating('\n', margin.top) + repeating(' ', margin.left) + chars.topLeft + horizontal + chars.topRight);
+	var bottom = colorizeBorder(repeating(' ', margin.left) + chars.bottomLeft + horizontal + chars.bottomRight + repeating('\n', margin.bottom));
+	var side = colorizeBorder(chars.vertical);
 
 	var middle = lines.map(function (line) {
 		var paddingLeft = repeating(' ', padding.left);

--- a/readme.md
+++ b/readme.md
@@ -26,14 +26,14 @@ console.log(boxen('unicorn', {padding: 1}));
 └─────────────┘
 */
 
-console.log(boxen('unicorn', {padding: 1, margin: 1}));
+console.log(boxen('unicorn', {padding: 1, margin: 1, borderStyle: 'double'}));
 /*
 
-   ┌─────────────┐
-   │             │
-   │   unicorn   │
-   │             │
-   └─────────────┘
+   ╔═════════════╗
+   ║             ║
+   ║   unicorn   ║
+   ║             ║
+   ╚═════════════╝
 
 */
 ```
@@ -57,6 +57,54 @@ Type: `string`
 Values: `black` `red` `green` `yellow` `blue` `magenta` `cyan` `white` `gray`
 
 Color of the box border.
+
+##### borderStyle
+
+Type: `string`, `object`
+Default: `single`
+Values:
+- `single`, e.g.
+```
+┌───┐
+│foo│
+└───┘
+```
+- `double`, e.g.
+```
+╔═══╗
+║foo║
+╚═══╝
+```
+- `round` (`single` sides with round corners), e.g.
+```
+╭───╮
+│foo│
+╰───╯
+```
+- `single-double` (`single` on top and bottom, `double` on right and left), e.g.
+```
+╓───╖
+║foo║
+╙───╜
+```
+- `double-single` (`double` on top and bottom, `single` on right and left), e.g.
+```
+╒═══╕
+│foo│
+╘═══╛
+```
+
+Style of the box border. Can be any of the predefined styles from above or an object with the following keys:
+
+- `topLeft`: The string to use for the top-left corner
+- `topRight`: The string to use for the top-right corner
+- `bottomLeft`: The string to use for the bottom-left corner
+- `bottomRight`: The string to use for the bottom-right corner
+- `vertical`: The string to use for the vertical sides (right and left)
+- `horizontal`: The string to use for the horizontal sides (top and bottom)
+
+The following object would render an ASCII-like box: `{ topLeft: '+', topRight: '+', bottomLeft: '+', bottomRight '+', horizontal: '-', vertical: '|'};`.
+
 
 ##### padding
 

--- a/test.js
+++ b/test.js
@@ -44,7 +44,7 @@ test('padding option - advanced', t => {
 
 test('margin option', t => {
 	compare(t, fn('foo', {padding: 2, margin: 2}), `
-	
+
       ┌───────────────┐
       │               │
       │               │
@@ -52,6 +52,74 @@ test('margin option', t => {
       │               │
       │               │
       └───────────────┘
-      
+
     `);
+});
+
+test('borderStyle option `double`', t => {
+	compare(t, fn('foo', {borderStyle: 'double'}), `
+╔═══╗
+║foo║
+╚═══╝
+	`);
+});
+
+test('borderStyle option `round`', t => {
+	compare(t, fn('foo', {borderStyle: 'round'}), `
+╭───╮
+│foo│
+╰───╯
+	`);
+});
+
+test('borderStyle option `single-double`', t => {
+	compare(t, fn('foo', {borderStyle: 'single-double'}), `
+╓───╖
+║foo║
+╙───╜
+	`);
+});
+
+test('borderStyle option `double-single`', t => {
+	compare(t, fn('foo', {borderStyle: 'double-single'}), `
+╒═══╕
+│foo│
+╘═══╛
+	`);
+});
+
+test('borderStyle option with object', t => {
+	const asciiStyle = {
+		topLeft: '1', topRight: '2', bottomLeft: '3', bottomRight: '4', horizontal: '-', vertical: '|'
+	};
+	compare(t, fn('foo', {borderStyle: asciiStyle}), `
+1---2
+|foo|
+3---4
+	`);
+});
+
+test('throws (with hint) on unexpected borderStyle as string', t => {
+	t.throws(() => fn('foo', {borderStyle: 'shaken-snake'}), /borderStyle/);
+});
+
+test('throws (with hint) on unexpected borderStyle as object', t => {
+	t.throws(() => fn('foo', {borderStyle: {shake: 'snake'}}), /borderStyle/);
+	// missing bottomRight
+	const invalid = {
+		topLeft: '1', topRight: '2', bottomLeft: '3', horizontal: '-', vertical: '|'
+	};
+	t.throws(() => fn('foo', {borderStyle: invalid}), /bottomRight/);
+});
+
+test('borderColor option', t => {
+	const box = fn('foo', {borderColor: 'yellow'});
+	const yellowAnsiOpen = '\u001b[33m';
+	const colorAnsiClose = '\u001b[39m';
+	t.ok(box.indexOf(yellowAnsiOpen) !== -1);
+	t.ok(box.indexOf(colorAnsiClose) !== -1);
+})
+
+test('throws (with hint) on unexpected borderColor', t => {
+	t.throws(() => fn('foo', {borderColor: 'greasy-white'}), /borderColor/);
 });


### PR DESCRIPTION
This PR suggests to add a new option `borderStyle`, which can be used to change the style of the box that is drawn.

Possible values of the option:
* `'single'`
* `'double'`
* `'round'` (`single` sides with round corners)
* `'single-double'` (`single` on top and bottom, `double` on right and left)
* `'double-single'` (`double` on top and bottom, `single` on right and left)
* Or an object with the following keys:
  * `topLeft`: The string to use for the top-left corner
  * `topRight: The string to use for the top-right corner
  * `bottomLeft`: The string to use for the bottom-left corner
  * `bottomRight: The string to use for the bottom-right corner
  * `vertical`: The string to use for the vertical sides (right and left)
  * `horizontal`: The string to use for the horizontal sides (top and bottom) 

The default behaviour (draw `single` line boxes) is left unchanged.

While I was at it, I also added some tests for the `borderColor` option.

I am not sure if you want to have this in the module, but as I was happy with the result, I'd thought to give it back to you.