### PR TITLE
add `align` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,8 @@ module.exports = function (text, opts) {
 	opts = objectAssign({
 		padding: 0,
 		borderStyle: 'single',
-		dimBorder: false
+		dimBorder: false,
+		align: 'left'
 	}, opts);
 
 	if (opts.backgroundColor) {
@@ -98,13 +99,10 @@ module.exports = function (text, opts) {
 		return opts.backgroundColor ? chalk[opts.backgroundColor](x) : x;
 	};
 
+	text = ansiAlign(text, {align: opts.align});
+
 	var NL = '\n';
 	var PAD = ' ';
-
-	if (opts.align && opts.align !== 'left') {
-		text = ansiAlign(text, {align: opts.align});
-	}
-
 	var lines = text.split(NL);
 
 	if (padding.top > 0) {

--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ module.exports = function (text, opts) {
 	var NL = '\n';
 	var PAD = ' ';
 
-	if (opts.align) {
+	if (opts.align && opts.align !== 'left') {
 		text = ansiAlign(text, {
 			align: opts.align,
 			split: NL,

--- a/index.js
+++ b/index.js
@@ -102,11 +102,7 @@ module.exports = function (text, opts) {
 	var PAD = ' ';
 
 	if (opts.align && opts.align !== 'left') {
-		text = ansiAlign(text, {
-			align: opts.align,
-			split: NL,
-			pad: PAD
-		});
+		text = ansiAlign(text, {align: opts.align});
 	}
 
 	var lines = text.split(NL);

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var widestLine = require('widest-line');
 var filledArray = require('filled-array');
 var cliBoxes = require('cli-boxes');
 var camelCase = require('camelcase');
+var ansiAlign = require('ansi-align');
 
 var getObject = function (detail) {
 	var obj;
@@ -99,6 +100,15 @@ module.exports = function (text, opts) {
 
 	var NL = '\n';
 	var PAD = ' ';
+
+	if (opts.align) {
+		text = ansiAlign(text, {
+			align: opts.align,
+			split: NL,
+			pad: PAD
+		});
+	}
+
 	var lines = text.split(NL);
 
 	if (padding.top > 0) {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "text"
   ],
   "dependencies": {
+    "ansi-align": "^1.0.0",
     "camelcase": "^2.1.0",
     "chalk": "^1.1.1",
     "cli-boxes": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "text"
   ],
   "dependencies": {
-    "ansi-align": "^1.0.0",
+    "ansi-align": "^1.1.0",
     "camelcase": "^2.1.0",
     "chalk": "^1.1.1",
     "cli-boxes": "^1.0.0",

--- a/readme.md
+++ b/readme.md
@@ -147,6 +147,13 @@ Values: `black` `red` `green` `yellow` `blue` `magenta` `cyan` `white`
 
 Color of the background.
 
+##### align
+
+Type: `string`<br>
+Values: `center` `right`
+
+Align the text in the box based on the widest line.
+
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -150,7 +150,8 @@ Color of the background.
 ##### align
 
 Type: `string`<br>
-Values: `center` `right`
+Default: `left`<br>
+Values: `left` `center` `right`
 
 Align the text in the box based on the widest line.
 

--- a/test.js
+++ b/test.js
@@ -1,4 +1,5 @@
 import test from 'ava';
+import chalk from 'chalk';
 import fn from './';
 
 function compare(t, actual, expected) {
@@ -141,4 +142,31 @@ test('backgroundColor option', t => {
 
 test('throws on unexpected backgroundColor', t => {
 	t.throws(() => fn('foo', {backgroundColor: 'dark-yellow'}), /backgroundColor/);
+});
+
+test('align option `center`', t => {
+	const beautifulColor = chalk.magenta('B E A U T I F U L');
+	compare(t, fn(`Boxes are\n${beautifulColor}\nand beneficial too!`, {
+		align: 'center',
+		padding: 1
+	}), `
+┌─────────────────────────┐
+│                         │
+│        Boxes are        │
+│    ${beautifulColor}    │
+│   and beneficial too!   │
+│                         │
+└─────────────────────────┘
+	`);
+});
+
+test('align option `right`', t => {
+	const beautifulColor = chalk.magenta('B E A U T I F U L');
+	compare(t, fn(`Boxes are\n${beautifulColor}\nand beneficial too!`, {align: 'right'}), `
+┌───────────────────┐
+│          Boxes are│
+│  ${beautifulColor}│
+│and beneficial too!│
+└───────────────────┘
+	`);
 });

--- a/test.js
+++ b/test.js
@@ -170,3 +170,14 @@ test('align option `right`', t => {
 └───────────────────┘
 	`);
 });
+
+test('align option `left`', t => {
+	const beautifulColor = chalk.magenta('B E A U T I F U L');
+	compare(t, fn(`Boxes are\n${beautifulColor}\nand beneficial too!`, {align: 'left'}), `
+┌───────────────────┐
+│Boxes are          │
+│${beautifulColor}  │
+│and beneficial too!│
+└───────────────────┘
+	`);
+});


### PR DESCRIPTION
Add an `align` option that supports string values `'center'` and `'right'`, allowing consumers to center- or right-align their text within the box without any pre-padding logic.

My hope is to add center-alignment to `update-notifier` "out-of-the-box" (pun intended) just by passing `align: 'center'` to `boxen`.

Here are examples (with `padding: 1`):

<img width="202" alt="screen shot 2016-06-06 at 12 54 42 pm" src="https://cloud.githubusercontent.com/assets/1929625/15830378/e73d82aa-2be5-11e6-917b-489382a057f1.png">
