### PR TITLE
Version bump.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boxen",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Create boxes in the terminal",
   "license": "MIT",
   "repository": "sindresorhus/boxen",


### PR DESCRIPTION
We missed this before. Please `npm publish` as well so I can push the new `boxen-cli`