### PR TITLE
Update `ansi-align` dependency to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "text"
   ],
   "dependencies": {
-    "ansi-align": "^1.1.0",
+    "ansi-align": "^2.0.0",
     "camelcase": "^4.0.0",
     "chalk": "^1.1.1",
     "cli-boxes": "^1.0.0",

--- a/test.js
+++ b/test.js
@@ -152,7 +152,7 @@ test('throws on unexpected borderStyle as string', t => {
 test('throws on unexpected borderStyle as object', t => {
 	t.throws(() => m('foo', {borderStyle: {shake: 'snake'}}), /border style/);
 
-	// missing bottomRight
+	// Missing bottomRight
 	const invalid = {
 		topLeft: '1',
 		topRight: '2',


### PR DESCRIPTION
Also reduce required transient versions of string-width (both boxen and ansi-align will now use `"string-width": "^2.0.0"` dependency range).

See [ansi-align changes between 1.1.0 and 2.0.0 here](https://github.com/nexdrew/ansi-align/compare/v1.1.0...v2.0.0).