### PR TITLE
Use `nyc` to report code coverage and make sure all lines covered

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.nyc_output

--- a/index.js
+++ b/index.js
@@ -118,8 +118,7 @@ module.exports = (text, opts) => {
 		const padWidth = (columns - contentWidth) / 2;
 		marginLeft = PAD.repeat(padWidth);
 	} else if (opts.float === 'right') {
-		let padWidth = Math.max(columns - contentWidth - 2, 0);
-		padWidth = padWidth < 0 ? 0 : padWidth;
+		const padWidth = Math.max(columns - contentWidth - 2, 0);
 		marginLeft = PAD.repeat(padWidth);
 	}
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">=4"
   },
   "scripts": {
-    "test": "xo && ava"
+    "test": "xo && nyc ava"
   },
   "files": [
     "index.js"
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "ava": "*",
+    "nyc": "^10.3.0",
     "xo": "*"
   },
   "xo": {

--- a/test.js
+++ b/test.js
@@ -152,7 +152,7 @@ test('throws on unexpected borderStyle as string', t => {
 test('throws on unexpected borderStyle as object', t => {
 	t.throws(() => m('foo', {borderStyle: {shake: 'snake'}}), /border style/);
 
-	// missing bottomRight
+	// Missing bottomRight
 	const invalid = {
 		topLeft: '1',
 		topRight: '2',

--- a/test.js
+++ b/test.js
@@ -225,3 +225,14 @@ test('align option `left`', t => {
 └───────────────────┘
 	`);
 });
+
+test('dimBorder option', t => {
+	const dimTopBorder = chalk.dim('┌───┐');
+	const dimSide = chalk.dim('│');
+	const dimBottomBorder = chalk.dim('└───┘');
+	compare(t, m('foo', {dimBorder: true}), `
+${dimTopBorder}
+${dimSide}foo${dimSide}
+${dimBottomBorder}
+	`);
+});


### PR DESCRIPTION
Just a suggestion to make sure tests cover all options available in the API and to make sure future changes don't introduce code coverage regression.

Note that I get this without any changes to code/tests:
<img width="517" alt="current coverage" src="https://cloud.githubusercontent.com/assets/1929625/25598952/5be44652-2ea6-11e7-8c7e-cd4021fbd1f2.png">

Also note that I expect xo to fail until we address the comment capitalization on line 155 of test.js (which was included in PR #17).

TODO:
- [x] Address the uncovered lines with tests or production code modification
- [x] Make sure codebase satisfies current xo requirements