### PR TITLE
Update term-size to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "chalk": "^1.1.1",
     "cli-boxes": "^1.0.0",
     "string-width": "^2.0.0",
-    "term-size": "^0.1.0",
+    "term-size": "^0.1.1",
     "widest-line": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The new macos-term-size binary might fix https://github.com/zeit/serve/issues/172