### PR TITLE
Update termsize to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "chalk": "^1.1.1",
     "cli-boxes": "^1.0.0",
     "string-width": "^2.0.0",
-    "term-size": "^0.1.0",
+    "term-size": "^1.2.0",
     "widest-line": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
To avoid obsolete execa dependency.