### PR TITLE
Add ability to pass hex color to the `borderColor` and `backgroundColor ` options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ language: node_js
 node_js:
   - '8'
   - '6'
-  - '4'

--- a/example.js
+++ b/example.js
@@ -18,15 +18,15 @@ console.log('\n\n' + boxen(chalk.blue.bold('unicorn'), {
 console.log('\n\n' + boxen(chalk.blue.bold('unicorn'), {
 	padding: 1,
 	margin: 1,
-	borderColor: chalk.hex('#eebbaa'),
+	borderColor: '#eebbaa',
 	borderStyle: 'double'
 }) + '\n');
 
 console.log('\n\n' + boxen(chalk.blue.bold('unicorn'), {
 	padding: 1,
 	margin: 1,
-	borderColor: chalk.keyword('pink'),
-	backgroundColor: chalk.bgKeyword('cyan'),
+	borderColor: '#FFC0CB',
+	backgroundColor: '#00FFFF',
 	borderStyle: 'double'
 }) + '\n');
 

--- a/example.js
+++ b/example.js
@@ -18,6 +18,20 @@ console.log('\n\n' + boxen(chalk.blue.bold('unicorn'), {
 console.log('\n\n' + boxen(chalk.blue.bold('unicorn'), {
 	padding: 1,
 	margin: 1,
+	borderColor: chalk.hex('#eebbaa'),
+	borderStyle: 'double'
+}) + '\n');
+
+console.log('\n\n' + boxen(chalk.blue.bold('unicorn'), {
+	padding: 1,
+	margin: 1,
+	borderColor: chalk.keyword('pink'),
+	borderStyle: 'double'
+}) + '\n');
+
+console.log('\n\n' + boxen(chalk.blue.bold('unicorn'), {
+	padding: 1,
+	margin: 1,
 	borderColor: 'yellow',
 	backgroundColor: 'magenta',
 	borderStyle: {

--- a/example.js
+++ b/example.js
@@ -26,6 +26,7 @@ console.log('\n\n' + boxen(chalk.blue.bold('unicorn'), {
 	padding: 1,
 	margin: 1,
 	borderColor: chalk.keyword('pink'),
+	backgroundColor: chalk.bgKeyword('cyan'),
 	borderStyle: 'double'
 }) + '\n');
 

--- a/index.js
+++ b/index.js
@@ -60,11 +60,11 @@ const getBorderChars = borderStyle => {
 	return chars;
 };
 
-const getBackgroundColorName = x => camelCase(['bg', String(x)]);
-
-// Color must either be a valid chalk color function or a function
-const isColorValid = color => !((typeof color === 'string' && chalk[color]) || typeof color === 'function');
-const getColorFn = color => typeof color === 'function' ? color : chalk[color];
+// Color must either be a valid chalk color or a color hex ( #55aabb )
+const isHex = color => color.match(/^#[0-f]{6}/i);
+const isColorValid = color => !(typeof color === 'string' && ((chalk[color]) || isHex(color)));
+const getColorFn = color => isHex(color) ? chalk.hex(color) : chalk[color];
+const getBGColorFn = color => isHex(color) ? chalk.bgHex(color) : chalk[camelCase('bg', color)];
 
 module.exports = (text, opts) => {
 	opts = Object.assign({
@@ -74,10 +74,6 @@ module.exports = (text, opts) => {
 		align: 'left',
 		float: 'left'
 	}, opts);
-
-	if (opts.backgroundColor) {
-		opts.backgroundColor = typeof opts.backgroundColor === 'function' ? opts.backgroundColor : getBackgroundColorName(opts.backgroundColor);
-	}
 
 	if (opts.borderColor && isColorValid(opts.borderColor)) {
 		throw new Error(`${opts.borderColor} is not a valid borderColor`);
@@ -96,7 +92,7 @@ module.exports = (text, opts) => {
 		return opts.dimBorder ? chalk.dim(ret) : ret;
 	};
 
-	const colorizeContent = x => opts.backgroundColor ? getColorFn(opts.backgroundColor)(x) : x;
+	const colorizeContent = x => opts.backgroundColor ? getBGColorFn(opts.backgroundColor)(x) : x;
 
 	text = ansiAlign(text, {align: opts.align});
 

--- a/index.js
+++ b/index.js
@@ -60,7 +60,11 @@ const getBorderChars = borderStyle => {
 	return chars;
 };
 
-const getBackgroundColorName = x => camelCase('bg', x);
+const getBackgroundColorName = x => camelCase(['bg', x]);
+
+// color must either be a valid chalk color function or a function
+const isColorValid = color => !((typeof color === 'string' && chalk[color]) || typeof color === 'function')
+const getColorFn = color => typeof color === 'function' ? color : chalk[color];
 
 module.exports = (text, opts) => {
 	opts = Object.assign({
@@ -75,11 +79,11 @@ module.exports = (text, opts) => {
 		opts.backgroundColor = getBackgroundColorName(opts.backgroundColor);
 	}
 
-	if (opts.borderColor && !chalk[opts.borderColor]) {
+	if (opts.borderColor && isColorValid(opts.borderColor)) {
 		throw new Error(`${opts.borderColor} is not a valid borderColor`);
 	}
 
-	if (opts.backgroundColor && !chalk[opts.backgroundColor]) {
+	if (opts.backgroundColor && isColorValid(opts.backgroundColor)) {
 		throw new Error(`${opts.backgroundColor} is not a valid backgroundColor`);
 	}
 
@@ -88,11 +92,12 @@ module.exports = (text, opts) => {
 	const margin = getObject(opts.margin);
 
 	const colorizeBorder = x => {
-		const ret = opts.borderColor ? chalk[opts.borderColor](x) : x;
+		const ret = opts.borderColor ? getColorFn(opts.borderColor)(x) : x;
 		return opts.dimBorder ? chalk.dim(ret) : ret;
 	};
 
-	const colorizeContent = x => opts.backgroundColor ? chalk[opts.backgroundColor](x) : x;
+	
+	const colorizeContent = x => opts.backgroundColor ? getColorFn(opts.backgroundColor)(x) : x;
 
 	text = ansiAlign(text, {align: opts.align});
 

--- a/index.js
+++ b/index.js
@@ -60,10 +60,14 @@ const getBorderChars = borderStyle => {
 	return chars;
 };
 
-const getBackgroundColorName = x => camelCase(['bg', x]);
+const getBackgroundColorName = x => {
+	const input = ['bg', String(x)];
+	const result = camelCase(input);
+	return result;
+};
 
-// color must either be a valid chalk color function or a function
-const isColorValid = color => !((typeof color === 'string' && chalk[color]) || typeof color === 'function')
+// Color must either be a valid chalk color function or a function
+const isColorValid = color => !((typeof color === 'string' && chalk[color]) || typeof color === 'function');
 const getColorFn = color => typeof color === 'function' ? color : chalk[color];
 
 module.exports = (text, opts) => {
@@ -76,7 +80,7 @@ module.exports = (text, opts) => {
 	}, opts);
 
 	if (opts.backgroundColor) {
-		opts.backgroundColor = getBackgroundColorName(opts.backgroundColor);
+		opts.backgroundColor = typeof opts.backgroundColor === 'function' ? opts.backgroundColor : getBackgroundColorName(opts.backgroundColor);
 	}
 
 	if (opts.borderColor && isColorValid(opts.borderColor)) {
@@ -84,6 +88,7 @@ module.exports = (text, opts) => {
 	}
 
 	if (opts.backgroundColor && isColorValid(opts.backgroundColor)) {
+		console.log(opts.backgroundColor);
 		throw new Error(`${opts.backgroundColor} is not a valid backgroundColor`);
 	}
 
@@ -96,7 +101,6 @@ module.exports = (text, opts) => {
 		return opts.dimBorder ? chalk.dim(ret) : ret;
 	};
 
-	
 	const colorizeContent = x => opts.backgroundColor ? getColorFn(opts.backgroundColor)(x) : x;
 
 	text = ansiAlign(text, {align: opts.align});

--- a/index.js
+++ b/index.js
@@ -60,11 +60,7 @@ const getBorderChars = borderStyle => {
 	return chars;
 };
 
-const getBackgroundColorName = x => {
-	const input = ['bg', String(x)];
-	const result = camelCase(input);
-	return result;
-};
+const getBackgroundColorName = x => camelCase(['bg', String(x)]);
 
 // Color must either be a valid chalk color function or a function
 const isColorValid = color => !((typeof color === 'string' && chalk[color]) || typeof color === 'function');
@@ -88,7 +84,6 @@ module.exports = (text, opts) => {
 	}
 
 	if (opts.backgroundColor && isColorValid(opts.backgroundColor)) {
-		console.log(opts.backgroundColor);
 		throw new Error(`${opts.backgroundColor} is not a valid backgroundColor`);
 	}
 

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ const getBorderChars = borderStyle => {
 };
 
 // Color must either be a valid chalk color or a color hex ( #55aabb )
-const isHex = color => color.match(/^#[0-f]{6}/i);
+const isHex = color => color.match(/^#[0-f]{3}(?:[0-f]{3})?$/i);
 const isColorValid = color => !(typeof color === 'string' && ((chalk[color]) || isHex(color)));
 const getColorFn = color => isHex(color) ? chalk.hex(color) : chalk[color];
 const getBGColorFn = color => isHex(color) ? chalk.bgHex(color) : chalk[camelCase('bg', color)];

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ module.exports = (text, opts) => {
 
 	const contentWidth = widestLine(text) + padding.left + padding.right;
 	const paddingLeft = PAD.repeat(padding.left);
-	const columns = termSize().columns;
+	const {columns} = termSize();
 	let marginLeft = PAD.repeat(margin.left);
 
 	if (opts.float === 'center') {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 	],
 	"dependencies": {
 		"ansi-align": "^2.0.0",
-		"camelcase": "^5.0.0",
+		"camelcase": "^4.0.0",
 		"chalk": "^2.0.1",
 		"cli-boxes": "^1.0.0",
 		"string-width": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 	],
 	"dependencies": {
 		"ansi-align": "^2.0.0",
-		"camelcase": "^4.0.0",
+		"camelcase": "^5.0.0",
 		"chalk": "^2.0.1",
 		"cli-boxes": "^1.0.0",
 		"string-width": "^2.0.0",

--- a/readme.md
+++ b/readme.md
@@ -159,7 +159,7 @@ Float the box on the available terminal screen space.
 
 Type: `string` or `function`<br>
 Values: `black` `red` `green` `yellow` `blue` `magenta` `cyan` `white` `gray`
-Value in the case of a function should be a `chalk.hex` or `chalk.rgb` or any other [chalk color models](https://github.com/chalk/chalk#256-and-truecolor-color-support)
+Value in the case of a function should be a `chalk.bgHex` or `chalk.bgRgb` or any other [chalk color models **background variant**](https://github.com/chalk/chalk#256-and-truecolor-color-support)
 
 Color of the background.
 

--- a/readme.md
+++ b/readme.md
@@ -59,8 +59,9 @@ Type: `Object`
 
 ##### borderColor
 
-Type: `string`<br>
+Type: `string` or `function`<br>
 Values: `black` `red` `green` `yellow` `blue` `magenta` `cyan` `white` `gray`
+Value in the case of a function should be a `chalk.hex` or `chalk.rgb` or any other [chalk color models](https://github.com/chalk/chalk#256-and-truecolor-color-support)
 
 Color of the box border.
 
@@ -156,8 +157,9 @@ Float the box on the available terminal screen space.
 
 ##### backgroundColor
 
-Type: `string`<br>
-Values: `black` `red` `green` `yellow` `blue` `magenta` `cyan` `white`
+Type: `string` or `function`<br>
+Values: `black` `red` `green` `yellow` `blue` `magenta` `cyan` `white` `gray`
+Value in the case of a function should be a `chalk.hex` or `chalk.rgb` or any other [chalk color models](https://github.com/chalk/chalk#256-and-truecolor-color-support)
 
 Color of the background.
 

--- a/readme.md
+++ b/readme.md
@@ -60,8 +60,7 @@ Type: `Object`
 ##### borderColor
 
 Type: `string` or `function`<br>
-Values: `black` `red` `green` `yellow` `blue` `magenta` `cyan` `white` `gray`
-Value in the case of a function should be a `chalk.hex` or `chalk.rgb` or any other [chalk color models](https://github.com/chalk/chalk#256-and-truecolor-color-support)
+Values: `black` `red` `green` `yellow` `blue` `magenta` `cyan` `white` `gray` or a hex value like so: `#FF0000`
 
 Color of the box border.
 
@@ -157,9 +156,8 @@ Float the box on the available terminal screen space.
 
 ##### backgroundColor
 
-Type: `string` or `function`<br>
-Values: `black` `red` `green` `yellow` `blue` `magenta` `cyan` `white` `gray`
-Value in the case of a function should be a `chalk.bgHex` or `chalk.bgRgb` or any other [chalk color models **background variant**](https://github.com/chalk/chalk#256-and-truecolor-color-support)
+Type: `string`
+Values: `black` `red` `green` `yellow` `blue` `magenta` `cyan` `white` `gray` or a hex value like so: `#FF0000`
 
 Color of the background.
 

--- a/test.js
+++ b/test.js
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import m from '.';
 
 chalk.enabled = true;
+chalk.level = 3;
 
 const compare = (t, actual, expected) => t.is(actual.trim(), expected.trim());
 

--- a/test.js
+++ b/test.js
@@ -233,11 +233,11 @@ test('borderColor option', t => {
 	t.true(box.indexOf(colorAnsiClose) !== -1);
 });
 
-test('borderColor function', t => {
-	const box = m('foo', {borderColor: chalk.yellow});
-	const yellowAnsiOpen = '\u001B[33m';
+test('borderColor hex', t => {
+	const box = m('foo', {borderColor: '#FF0000'});
+	const rgbAnsiOpen = '\u001B[38;2;255;0;0m';
 	const colorAnsiClose = '\u001B[39m';
-	t.true(box.indexOf(yellowAnsiOpen) !== -1);
+	t.true(box.indexOf(rgbAnsiOpen) !== -1);
 	t.true(box.indexOf(colorAnsiClose) !== -1);
 });
 
@@ -253,12 +253,12 @@ test('backgroundColor option', t => {
 	t.true(box.indexOf(redAnsiClose) !== -1);
 });
 
-test('backgroundColor function', t => {
-	const box = m('foo', {backgroundColor: chalk.bgRed});
-	const redAnsiOpen = '\u001B[41m';
-	const redAnsiClose = '\u001B[49m';
-	t.true(box.indexOf(redAnsiOpen) !== -1);
-	t.true(box.indexOf(redAnsiClose) !== -1);
+test('backgroundColor hex', t => {
+	const box = m('foo', {backgroundColor: '#FF0000'});
+	const rgbAnsiOpen = '\u001B[48;2;255;0;0m';
+	const colorAnsiClose = '\u001B[49m';
+	t.true(box.indexOf(rgbAnsiOpen) !== -1);
+	t.true(box.indexOf(colorAnsiClose) !== -1);
 });
 
 test('throws on unexpected backgroundColor', t => {

--- a/test.js
+++ b/test.js
@@ -254,7 +254,7 @@ test('backgroundColor option', t => {
 });
 
 test('backgroundColor function', t => {
-	const box = m('foo', {backgroundColor: chalk.red});
+	const box = m('foo', {backgroundColor: chalk.bgRed});
 	const redAnsiOpen = '\u001B[41m';
 	const redAnsiClose = '\u001B[49m';
 	t.true(box.indexOf(redAnsiOpen) !== -1);

--- a/test.js
+++ b/test.js
@@ -233,12 +233,28 @@ test('borderColor option', t => {
 	t.true(box.indexOf(colorAnsiClose) !== -1);
 });
 
+test('borderColor function', t => {
+	const box = m('foo', {borderColor: chalk.yellow});
+	const yellowAnsiOpen = '\u001B[33m';
+	const colorAnsiClose = '\u001B[39m';
+	t.true(box.indexOf(yellowAnsiOpen) !== -1);
+	t.true(box.indexOf(colorAnsiClose) !== -1);
+});
+
 test('throws on unexpected borderColor', t => {
 	t.throws(() => m('foo', {borderColor: 'greasy-white'}), /borderColor/);
 });
 
 test('backgroundColor option', t => {
 	const box = m('foo', {backgroundColor: 'red'});
+	const redAnsiOpen = '\u001B[41m';
+	const redAnsiClose = '\u001B[49m';
+	t.true(box.indexOf(redAnsiOpen) !== -1);
+	t.true(box.indexOf(redAnsiClose) !== -1);
+});
+
+test('backgroundColor function', t => {
+	const box = m('foo', {backgroundColor: chalk.red});
 	const redAnsiOpen = '\u001B[41m';
 	const redAnsiClose = '\u001B[49m';
 	t.true(box.indexOf(redAnsiOpen) !== -1);


### PR DESCRIPTION
I want my borders pink, so I added that feature. fixes #33 

This also does upgrade `camelcase`, which removes node support <6
If you want that reverted, let me know.

I added docs & test & examples.

<img width="205" alt="screen shot 2018-04-03 at 00 24 25" src="https://user-images.githubusercontent.com/3070389/38219350-70f89a88-36d5-11e8-807d-d5ef97c866f0.png">
