### PR TITLE
Support text wrapping and added correct splitting of strings containing ANSI style codes

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,8 +160,10 @@ module.exports = (text, options) => {
 	let marginLeft = PAD.repeat(margin.left);
 
 	if (columns < contentWidth + margin.right + margin.left) {
-		const newWidestLine = widestLine(text) + (columns - (contentWidth + margin.right + margin.left));
-
+		if (opts.float) {
+			delete opts.float;
+		}
+		const newWidestLine = widestLine(text) + (columns - (contentWidth + margin.right + margin.left)) - 2; // The 2 is for the two box characters
 		const wrapText = wrapAnsi(text, newWidestLine, {hard: true});
 		lines = new Array(padding.top).fill('')
 			.concat(hasAnsi(wrapText) ? splitAnsiCorrectly(wrapText) : wrapText.split(NL))

--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ const cliBoxes = require('cli-boxes');
 const camelCase = require('camelcase');
 const ansiAlign = require('ansi-align');
 const termSize = require('term-size');
+const wrapAnsi = require('wrap-ansi');
+const hasAnsi = require('has-ansi')
+const ansi_Split = require('ansi-split')
 
 const getObject = detail => {
 	let object;
@@ -65,6 +68,46 @@ const isHex = color => color.match(/^#[0-f]{3}(?:[0-f]{3})?$/i);
 const isColorValid = color => typeof color === 'string' && ((chalk[color]) || isHex(color));
 const getColorFn = color => isHex(color) ? chalk.hex(color) : chalk[color];
 const getBGColorFn = color => isHex(color) ? chalk.bgHex(color) : chalk[camelCase(['bg', color])];
+const ansiSplit = text => {
+	let lines = []
+	let currStr = ""
+	let resetAnsi = '\u001b[39m'
+	let lastAnsi = resetAnsi
+
+	for(const el of ansi_Split(text)){
+		if(el === ""){
+			continue
+		}
+
+		if(hasAnsi(el)){
+			const ansiCodes = el.split("m")
+			lastAnsi = ansiCodes[ansiCodes.length - 2]
+			currStr += lastAnsi + 'm'
+		}
+		else{
+			let nlIndex
+			let txt = el
+			do{
+				nlIndex = txt.indexOf("\n")
+				if(nlIndex === -1){
+					currStr += txt
+				}
+				else{
+					currStr += txt.slice(0, nlIndex) + resetAnsi
+					lines.push(currStr)
+					currStr = ""
+					currStr += lastAnsi + 'm'
+					txt = txt.slice(nlIndex+1)
+				}
+			}while(nlIndex !== -1)
+		}
+	}
+	lines.push(currStr)
+
+	return lines;
+}
+
+const getBackgroundColorName = x => camelCase('bg', x);
 
 module.exports = (text, options) => {
 	options = {
@@ -100,7 +143,7 @@ module.exports = (text, options) => {
 	const NL = '\n';
 	const PAD = ' ';
 
-	let lines = text.split(NL);
+	let lines = hasAnsi(text) ?  ansiSplit(text) : text.split(NL);
 
 	if (padding.top > 0) {
 		lines = new Array(padding.top).fill('').concat(lines);
@@ -110,10 +153,19 @@ module.exports = (text, options) => {
 		lines = lines.concat(new Array(padding.bottom).fill(''));
 	}
 
-	const contentWidth = widestLine(text) + padding.left + padding.right;
+	let contentWidth = widestLine(text) + padding.left + padding.right;
 	const paddingLeft = PAD.repeat(padding.left);
 	const {columns} = termSize();
 	let marginLeft = PAD.repeat(margin.left);
+
+	if(columns < contentWidth + margin.right + margin.left){
+		const newWidestLine = widestLine(text) - (contentWidth + margin.right + margin.left - columns);
+		const wrapText = wrapAnsi(text, newWidestLine, {hard: true});
+		lines = new Array(padding.top).fill('')
+				.concat(hasAnsi(wrapText) ?  ansiSplit(wrapText) : text.split(NL))
+				.concat(new Array(padding.bottom).fill(''));
+		contentWidth = widestLine(wrapText) + padding.left + padding.right;
+	}
 
 	if (options.float === 'center') {
 		const padWidth = Math.max((columns - contentWidth) / 2, 0);
@@ -129,6 +181,8 @@ module.exports = (text, options) => {
 	const side = colorizeBorder(chars.vertical);
 
 	const middle = lines.map(line => {
+		console.log(line)
+		console.log(contentWidth - stringWidth(line) - padding.left);
 		const paddingRight = PAD.repeat(contentWidth - stringWidth(line) - padding.left);
 		return marginLeft + side + colorizeContent(paddingLeft + line + paddingRight) + side;
 	}).join(NL);

--- a/index.js
+++ b/index.js
@@ -159,10 +159,11 @@ module.exports = (text, options) => {
 	let marginLeft = PAD.repeat(margin.left);
 
 	if(columns < contentWidth + margin.right + margin.left){
-		const newWidestLine = widestLine(text) - (contentWidth + margin.right + margin.left - columns);
+		const newWidestLine = widestLine(text) + (columns - (contentWidth + margin.right + margin.left));
+		
 		const wrapText = wrapAnsi(text, newWidestLine, {hard: true});
 		lines = new Array(padding.top).fill('')
-				.concat(hasAnsi(wrapText) ?  ansiSplit(wrapText) : text.split(NL))
+				.concat(hasAnsi(wrapText) ?  ansiSplit(wrapText) : wrapText.split(NL))
 				.concat(new Array(padding.bottom).fill(''));
 		contentWidth = widestLine(wrapText) + padding.left + padding.right;
 	}
@@ -181,8 +182,6 @@ module.exports = (text, options) => {
 	const side = colorizeBorder(chars.vertical);
 
 	const middle = lines.map(line => {
-		console.log(line)
-		console.log(contentWidth - stringWidth(line) - padding.left);
 		const paddingRight = PAD.repeat(contentWidth - stringWidth(line) - padding.left);
 		return marginLeft + side + colorizeContent(paddingLeft + line + paddingRight) + side;
 	}).join(NL);

--- a/package.json
+++ b/package.json
@@ -39,7 +39,10 @@
 		"string-width": "^4.1.0",
 		"term-size": "^2.1.0",
 		"type-fest": "^0.5.2",
-		"widest-line": "^3.1.0"
+		"widest-line": "^3.1.0",
+		"ansi-split": "^1.0.1",
+		"has-ansi": "^3.0.0",
+		"wrap-ansi": "^3.0.1"
 	},
 	"devDependencies": {
 		"ava": "^2.1.0",

--- a/test.js
+++ b/test.js
@@ -326,3 +326,11 @@ ${dimSide}foo${dimSide}
 ${dimBottomBorder}
 	`);
 });
+
+test('text wraps when content > columns', t => {
+	const longContent = 'ab'.repeat(process.stdout.columns);
+	const lineLengths = m(longContent).split('\n').map(line => line.length);
+	for (const len of lineLengths) {
+		t.is(len, process.stdout.columns);
+	}
+});


### PR DESCRIPTION
This PR resolves #16 and also fixes #35.

A condition was added to see whether the size of the content together with padding and margin would be larger than the number of columns available and if so it would use `wrap-ansi` to bring the content down to a size where the content fits just right on the terminal.

Also, when the string to place within the box contains ANSI codes, a new method will be used to split the strnig which correctly places ANSI style codes in order to maintain the expected style both on the string and the box.