### PR TITLE
Don't use TypeScript `const enum`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -126,7 +126,7 @@ declare namespace boxen {
 	}
 }
 
-declare const enum BorderStyle {
+declare enum BorderStyle {
 	Single = 'single',
 	Double = 'double',
 	Round = 'round',


### PR DESCRIPTION
This PR replaces the `const enum` in index.d.ts with a regular enum. This lets boxen (or any packages that depend on it) be used in projects whose tsconfig has the setting `isolatedModules:true`.

---

Hi! I was going to make an issue, but figured I'd make a PR with a suggested fix too. 

Problem: I want to use [update-notifier](https://github.com/yeoman/update-notifier/) in a typescript project. My project has `isolatedModules: true` (because we're compiling with babel-preset-typescript, and trying to match variations across the two). Trying to typecheck this project fails with 
```
$ node_modules/.bin/tsc
node_modules/boxen/index.d.ts:172:22 - error TS2748: Cannot access ambient const enums when the '--isolatedModules' flag is provided.

172  BorderStyle: typeof BorderStyle;
                         ~~~~~~~~~~~


Found 1 error.
```

which is expected, of course. But I can't seem to figure out a workaround for this that doesn't rely on using `skipLibCheck: true`, which would suck. Would it be possible for you to replace the const enum here with a regular enum? I made this change locally and it appeared to work fine, but I'm not clear what the broader implications are. 

Please and thank you!