### PR TITLE
Fix crashes when wrapping text containing colorized content

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ module.exports = (text, options) => {
 			const createdLines = wrapAnsi(line, max, {hard: true});
 			const alignedLines = ansiAlign(createdLines, {align: options.align});
 			const alignedLinesArray = alignedLines.split('\n');
-			const longestLength = Math.max(...alignedLinesArray.map(s => s.length));
+			const longestLength = Math.max(...alignedLinesArray.map(s => stringWidth(s)));
 
 			for (const alignedLine of alignedLinesArray) {
 				let paddedLine;

--- a/test.js
+++ b/test.js
@@ -315,6 +315,34 @@ test('align option `left`', t => {
 	`);
 });
 
+test('align option (left) does not throw when colorized content > columns', t => {
+	console.log('process.stdout.columns', process.stdout.columns);
+	const longContent = chalk.green('ab').repeat(process.stdout.columns);
+	t.notThrows(() => {
+		boxen(longContent, {
+			align: 'left'
+		});
+	});
+});
+
+test('align option (center) does not throw when colorized content > columns', t => {
+	const longContent = chalk.green('ab').repeat(process.stdout.columns);
+	t.notThrows(() => {
+		boxen(longContent, {
+			align: 'center'
+		});
+	});
+});
+
+test('align option (right) does not throw when colorized content > columns', t => {
+	const longContent = chalk.green('ab').repeat(process.stdout.columns);
+	t.notThrows(() => {
+		boxen(longContent, {
+			align: 'right'
+		});
+	});
+});
+
 test('dimBorder option', t => {
 	const dimTopBorder = chalk.dim('┌───┐');
 	const dimSide = chalk.dim('│');


### PR DESCRIPTION
Without this those repeats:
- https://github.com/Andarist/boxen/blob/3f54ec18434a06efba93598376c277d9e08d7808/index.js#L133
- https://github.com/Andarist/boxen/blob/3f54ec18434a06efba93598376c277d9e08d7808/index.js#L136

were called with negative numbers - resulting with:
```
  RangeError {
    message: 'Invalid count value',
  }
```

This was happening because `max` was computed based on `contentWidth` which already handled colorized stuff correctly (thanks to `string-width` being used in `widest-line`) but the `longestLength` only used the `.length` property (so it was computed to a greater number):
https://github.com/Andarist/boxen/blob/de1f3c89e9c44823cc0c0a26b8b0fb113d648060/index.js#L127
