### PR TITLE
Bug fix: Ensure `title` is handled conditionally

### DIFF
--- a/index.js
+++ b/index.js
@@ -227,11 +227,11 @@ module.exports = (text, options) => {
 
 	if (title) {
 		title = ` ${title} `;
-	}
 
-	// Make the box larger to fit a larger title
-	if (stringWidth(title) > contentWidth) {
-		contentWidth = stringWidth(title);
+		// Make the box larger to fit a larger title
+		if (stringWidth(title) > contentWidth) {
+			contentWidth = stringWidth(title);
+		}
 	}
 
 	if ((margin.left && margin.right) && contentWidth + BORDERS_WIDTH + margin.left + margin.right > columns) {


### PR DESCRIPTION
We were just approached with bug report, where user was faced with
`TypeError: Cannot read property 'replace' of undefined` exception:

https://github.com/serverless/serverless/issues/9943

After digging into it, it appeared as it's caused by bug in `boxen` which was introduced with recently published feature.

I believe this patch fixes the issue.

/cc @Caesarovich