### PR TITLE
Don't trim whitespace in input text needlessly

### DIFF
--- a/index.js
+++ b/index.js
@@ -220,7 +220,7 @@ module.exports = (text, options) => {
 
 	const columns = terminalColumns();
 
-	let contentWidth = widestLine(wrapAnsi(text, columns - BORDERS_WIDTH, {hard: true})) + padding.left + padding.right;
+	let contentWidth = widestLine(wrapAnsi(text, columns - BORDERS_WIDTH, {hard: true, trim: false})) + padding.left + padding.right;
 
 	// This prevents the title bar to exceed the console's width
 	let title = options.title && options.title.slice(0, columns - 4 - margin.left - margin.right);

--- a/test.js
+++ b/test.js
@@ -679,13 +679,13 @@ test('box not overflowing terminal with words and margin', t => {
 
 	const lines = [];
 	for (let index = 1; index < 6; ++index) {
-		const line = box.slice(index * (word.length + 4), (index + 1) * (word.length + 4));
+		const line = box.slice(index * (word.length + 5), (index + 1) * (word.length + 5));
 		lines.push(line);
 	}
 
 	for (const line of lines) {
 		t.is(line.trim()[0], '│', 'First character of line isn\'t box border');
-		t.is(line.trim()[word.length], '│', 'Last character of line isn\'t box border');
+		t.is(line.trim()[word.length + 1], '│', 'Last character of line isn\'t box border');
 	}
 });
 
@@ -707,8 +707,8 @@ test('text is centered after wrapping when using words', t => {
 		t.is(paddingRight, rightPad, 'Padding right in line #' + index);
 	};
 
-	checkAlign({index: 1, leftPad: 0, rightPad: 0});
-	checkAlign({index: 2, leftPad: sentence.length, rightPad: sentence.length});
+	checkAlign({index: 1, leftPad: 0, rightPad: 1});
+	checkAlign({index: 2, leftPad: sentence.length, rightPad: sentence.length + 1});
 });
 
 test('text is left-aligned after wrapping when using words', t => {
@@ -729,8 +729,8 @@ test('text is left-aligned after wrapping when using words', t => {
 		t.is(paddingRight, rightPad, 'Padding right in line #' + index);
 	};
 
-	checkAlign({index: 1, leftPad: 0, rightPad: 0});
-	checkAlign({index: 2, leftPad: 0, rightPad: sentence.length * 2});
+	checkAlign({index: 1, leftPad: 0, rightPad: 1});
+	checkAlign({index: 2, leftPad: 0, rightPad: (sentence.length * 2) + 1});
 });
 
 test('text is right-aligned after wrapping when using words', t => {
@@ -751,8 +751,8 @@ test('text is right-aligned after wrapping when using words', t => {
 		t.is(paddingRight, rightPad, 'Padding right in line #' + index);
 	};
 
-	checkAlign({index: 1, leftPad: 0, rightPad: 0});
-	checkAlign({index: 2, leftPad: sentence.length * 2, rightPad: 0});
+	checkAlign({index: 1, leftPad: 1, rightPad: 0});
+	checkAlign({index: 2, leftPad: (sentence.length * 2) + 1, rightPad: 0});
 });
 
 test('text is right-aligned after wrapping when using words, with padding', t => {
@@ -776,6 +776,6 @@ test('text is right-aligned after wrapping when using words, with padding', t =>
 		t.is(paddingRight, rightPad, 'Padding right in line #' + index);
 	};
 
-	checkAlign({index: 1, leftPad: 1, rightPad: 1});
-	checkAlign({index: 2, leftPad: (sentence.length * 2) + 1, rightPad: 1});
+	checkAlign({index: 1, leftPad: 2, rightPad: 1});
+	checkAlign({index: 2, leftPad: (sentence.length * 2) + 2, rightPad: 1});
 });


### PR DESCRIPTION
This PR disables text trimming where it is unneeded. It comes in response to #62 

At line 233 there was this line of code:
```js
let contentWidth = widestLine(wrapAnsi(text, columns - BORDERS_WIDTH, {hard: true})) + padding.left + padding.right;
```
This line has for goal to determine the columns that the text would take with the padding.
The problem is that by default the `wrapAnsi` function trims the lines, hence removing the whitespaces in #62 . This is certainly an unwanted behavior because it alters the user input with no reason.
So I added the `trim: false` option in the wrapAnsi function.

I also needed to adapt my tests because it is not something I realized when making the code refactoring PR.

---

Fixes #62