### PR TITLE
Fix invalid escape in test string

### DIFF
--- a/tests/main.js
+++ b/tests/main.js
@@ -8,17 +8,17 @@ const formattedText = `
 !!!  Unicorns are lit !!!
 Hello this is a formatted text !
 				It has alignements
-				already includes 
-				in it. 
+				already includes${' '}
+				in it.${' '}
 Boxen should protect this alignement,
 		otherwise the users would be sad !
-Hehe          Haha                                 
+Hehe          Haha${' '.repeat(33)}
 Hihi       Hoho
 	All this garbage is on purpose.
 Have a good day !
 `;
 
-const randomText = 'lewb{+^PN_6-l 8eK2eqB:jn^YFgGl;wuT)mdA9TZlf 9}?X#P49`x"@+nLx:BH5p{5_b`S\'E8\0{A0l"(62`TIf(z8n2arEY~]y|bk,6,FYf~rGY*Xfa00q{=fdm=4.zVf6#\'|3S!`pJ3 6y02]nj2o4?-`1v$mudH?Wbw3fZ]a+aE\'\'P4Q(6:NHBry)L_&/7v]0<!7<kw~gLc.)\'ajS>\0~y\8PZ*|-BRY&m%UaCe\'3A,N?8&wbOP}*.O<47rnPzxO=4"*|[%A):;E)Z6!V&x!1*OprW-*+q<F$6|864~1HmYX@J#Nl1j1`!$Y~j^`j;PB2qpe[_;.+vJGnE3) yo&5qRI~WHxK~r%+\'P>Up&=P6M<kDdpSL#<Ur/[NN0qI3dFEEy|>_VGx0O/VOvPEez:7C58a^.N,"Rxc|a6C[i$3QC_)~x!wd+ZMtYsGF&?';
+const randomText = 'lewb{+^PN_6-l 8eK2eqB:jn^YFgGl;wuT)mdA9TZlf 9}?X#P49`x"@+nLx:BH5p{5_b`S\'E8\0{A0l"(62`TIf(z8n2arEY~]y|bk,6,FYf~rGY*Xfa00q{=fdm=4.zVf6#\'|3S!`pJ3 6y02]nj2o4?-`1v$mudH?Wbw3fZ]a+aE\'\'P4Q(6:NHBry)L_&/7v]0<!7<kw~gLc.)\'ajS>\0~y8PZ*|-BRY&m%UaCe\'3A,N?8&wbOP}*.O<47rnPzxO=4"*|[%A):;E)Z6!V&x!1*OprW-*+q<F$6|864~1HmYX@J#Nl1j1`!$Y~j^`j;PB2qpe[_;.+vJGnE3) yo&5qRI~WHxK~r%+\'P>Up&=P6M<kDdpSL#<Ur/[NN0qI3dFEEy|>_VGx0O/VOvPEez:7C58a^.N,"Rxc|a6C[i$3QC_)~x!wd+ZMtYsGF&?';
 
 test('creates a box', t => {
 	const box = boxen('foo');


### PR DESCRIPTION
`\8` is invalid in strict mode, it can run because we didn't enforce strict mode.

Found this in  [`eslint-plugin-unicorn` tests] (https://github.com/sindresorhus/eslint-plugin-unicorn/runs/3672252186#step:5:363)