### PR TITLE
Fix line separator for full-width boxes

### DIFF
--- a/index.js
+++ b/index.js
@@ -212,7 +212,7 @@ const boxContent = (content, contentWidth, options) => {
 	const top = colorizeBorder(NEWLINE.repeat(options.margin.top) + marginLeft + chars.topLeft + (options.title ? makeTitle(options.title, chars.top.repeat(contentWidth), options.titleAlignment) : chars.top.repeat(contentWidth)) + chars.topRight);
 	const bottom = colorizeBorder(marginLeft + chars.bottomLeft + chars.bottom.repeat(contentWidth) + chars.bottomRight + NEWLINE.repeat(options.margin.bottom));
 
-	const LINE_SEPARATOR = (contentWidth + BORDERS_WIDTH + options.margin.left >= columns) ? '' : NEWLINE;
+	const LINE_SEPARATOR = (contentWidth + BORDERS_WIDTH + options.margin.left > columns) ? '' : NEWLINE;
 
 	const lines = content.split(NEWLINE);
 


### PR DESCRIPTION
When running boxen in an environment in which the console columns cannot be detected, the column width defaults to 80 and the box width is capped at this same amount. The actual display width however, can still be greater (or even unlimited when piping to a file). Therefore we still need to use newlines when the box width equals the columns width.