### PR TITLE
Downgrade cli-boxes

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"ansi-align": "^3.0.1",
 		"camelcase": "^8.0.0",
 		"chalk": "^5.3.0",
-		"cli-boxes": "^4.0.0",
+		"cli-boxes": "^3.0.0",
 		"string-width": "^7.2.0",
 		"type-fest": "^4.21.0",
 		"widest-line": "^5.0.0",


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/boxen/pull/97#issuecomment-2265806741

In short, the upgrade caused issues because the `boxen` has supported "node 18" and not every one of those users are on "node 18.20" yet.

See reports in:

- https://github.com/withastro/astro/issues/11480

Since there are no improvements in v4, it's easier to stay on v3 for now.